### PR TITLE
add synced config toggle for AzuEPI Backpack slot

### DIFF
--- a/Backpacks/Backpacks.cs
+++ b/Backpacks/Backpacks.cs
@@ -27,6 +27,7 @@ public partial class Backpacks : BaseUnityPlugin
 	internal static readonly ConfigSync configSync = new(ModName) { DisplayName = ModName, CurrentVersion = ModVersion, MinimumRequiredVersion = ModVersion };
 
 	private static ConfigEntry<Toggle> serverConfigLocked = null!;
+	private static ConfigEntry<Toggle> addSlotAzuExtendedPlayerInventory = null!;
 	internal static SyncedConfigEntry<Toggle> useExternalYaml = null!;
 	public static ConfigEntry<Toggle> preventInventoryClosing = null!;
 	private static ConfigEntry<string> backpackRows = null!;
@@ -98,6 +99,7 @@ public partial class Backpacks : BaseUnityPlugin
 
 		serverConfigLocked = config("1 - General", "Lock Configuration", Toggle.On, "If on, the configuration is locked and can be changed by server admins only.");
 		configSync.AddLockingConfigEntry(serverConfigLocked);
+		addSlotAzuExtendedPlayerInventory = config("1 - General", "Add slot in AzuExtendedPlayerInventory", Toggle.On, new ConfigDescription("If on, a Backpack slot will be added to AzuExtendedPlayerInventory, if installed."));
 		useExternalYaml = configSync.AddConfigEntry(Config.Bind("2 - Backpack", "Use External YAML", Toggle.Off, "If set to on, the YAML file from your config folder will be used, to implement custom Backpacks inside of that file."));
 		useExternalYaml.SourceConfig.SettingChanged += (_, _) => ConfigLoader.reloadConfigFile();
 		config("2 - Backpack", "YAML Editor Anchor", 0, new ConfigDescription("Just ignore this.", null, new ConfigurationManagerAttributes { HideSettingName = true, HideDefaultButton = true, CustomDrawer = DrawYamlEditorButton }), false);
@@ -149,7 +151,7 @@ public partial class Backpacks : BaseUnityPlugin
 
 		Backpack.Prefab.GetComponent<ItemDrop>().m_itemData.Data().Add<ItemContainer>();
 
-		if (AzuExtendedPlayerInventory.API.IsLoaded())
+		if (addSlotAzuExtendedPlayerInventory.Value == Toggle.On && AzuExtendedPlayerInventory.API.IsLoaded())
 		{
 			AzuExtendedPlayerInventory.API.AddSlot("Backpack", player => Visual.visuals.TryGetValue(player.m_visEquipment, out Visual visual) ? visual.equippedBackpackItem : null, validateBackpack);
 		}


### PR DESCRIPTION
We add a new synced configuration toggle allowing to enable or disable adding the Backpack slot to AzuExtendedPlayerInventory (defaults to enabled).

With this, it is possible to have the Backpacks mod installed yet hide it completely from the users by disabling the default Explorers Backpack and removing the AzuExtendedPlayerInventory slot. This can be useful when the Backpacks mod is used as a dependency for something else but allowing backpacks themselves is not desired.

For example, [BowsBeforeHoes](https://thunderstore.io/c/valheim/p/Azumatt/BowsBeforeHoes/) depends on Backpacks to implement its quiver functionallity, however BowsBeforeHoes users might want to only enable quivers and not backpacks.